### PR TITLE
Adapt excluded prefixes service to use opentracing 

### DIFF
--- a/internal/prefixcollector/kubernetes_prefix_source.go
+++ b/internal/prefixcollector/kubernetes_prefix_source.go
@@ -21,8 +21,9 @@ import (
 	"context"
 	"net"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/spanhelper"
 )
 
 // KubernetesPrefixSource is excluded prefix source, which get prefixes
@@ -54,15 +55,18 @@ func NewKubernetesPrefixSource(ctx context.Context, notify Notifier) *Kubernetes
 }
 
 func (kps *KubernetesPrefixSource) watchSubnets(notify Notifier, clientSet kubernetes.Interface) {
+	span := spanhelper.FromContext(kps.ctx, "Watch k8s subnets")
+	defer span.Finish()
+
 	podChan, err := watchPodCIDR(kps.ctx, clientSet)
 	if err != nil {
-		logrus.Error(err)
+		span.Logger().Error(err)
 		return
 	}
 
 	serviceChan, err := watchServiceIPAddr(kps.ctx, clientSet)
 	if err != nil {
-		logrus.Error(err)
+		span.Logger().Error(err)
 		return
 	}
 

--- a/internal/prefixcollector/pod_monitor_server.go
+++ b/internal/prefixcollector/pod_monitor_server.go
@@ -135,9 +135,8 @@ func newServiceWatcher(ctx context.Context, cs kubernetes.Interface) (watch.Inte
 	for _, n := range ns {
 		w, err := cs.CoreV1().Services(n).Watch(ctx, metav1.ListOptions{})
 		if err != nil {
-			logrus.Errorf("Unable to watch services in %v namespace: %v", n, err)
 			close(stopCh)
-			return nil, err
+			return nil, errors.Wrapf(err, "Unable to watch services in %v namespace", n)
 		}
 
 		go func() {

--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/networkservicemesh/sdk-k8s/pkg/k8s"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/jaeger"
@@ -61,10 +60,10 @@ func main() {
 	// Get clientSetConfig from environment
 	config := &Config{}
 	if err := envconfig.Usage(envPrefix, config); err != nil {
-		logrus.Fatal(err)
+		span.Logger().Fatal(err)
 	}
 	if err := envconfig.Process(envPrefix, config); err != nil {
-		logrus.Fatalf("Error processing clientSetConfig from env: %v", err)
+		span.Logger().Fatalf("Error processing clientSetConfig from env: %v", err)
 	}
 
 	envPrefixes, err := validatedPrefixes(config.ExcludedPrefixes)
@@ -72,7 +71,7 @@ func main() {
 		span.Logger().Fatalf("Failed to parse prefixes from environment: %v", err)
 	}
 
-	span.Logger().Printf("Building Kubernetes clientSet...")
+	span.Logger().Info("Building Kubernetes clientSet...")
 	clientSetConfig, err := k8s.NewClientSetConfig()
 	if err != nil {
 		span.Logger().Fatalf("Failed to build Kubernetes clientSet: %v", err)


### PR DESCRIPTION
Logging directly with logrus was replaced with logging via `spanhelper.Logger()`