### PR TITLE
fix: apply fixes for golangci v1.35

### DIFF
--- a/internal/prefixcollector/collector_file_output_test.go
+++ b/internal/prefixcollector/collector_file_output_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -157,5 +157,5 @@ func (eps *ExcludedPrefixesSuite) watchFile(ctx context.Context, prefixesFilePat
 		}
 	}()
 
-	return
+	return watcher, errorCh
 }


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

Recently we've updated golangci to v1.35 and this produces ci fails: https://github.com/networkservicemesh/cmd-nsc/actions/runs/477788243