### PR TITLE
Switch from CMD to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ CMD dlv -l :40000 --headless=true --api-version=2 test -test.v ./...
 
 FROM alpine as runtime
 COPY --from=build /bin/exclude-prefixes /bin/exclude-prefixes
-CMD /bin/exclude-prefixes
+ENTRYPOINT ["/bin/exclude-prefixes"]


### PR DESCRIPTION
CMD runs a shell which then runs what is specified.

ENTRYPOINT simply runs what is specified

When K8s tries to delete a Pod, PAUSE sends SIGTERM to the
running process in the container.  After 30s, if the process
has not exited, PAUSE sends SIGKILL.

The container isn't *actually* deleted until PAUSE exits.
PAUSE will exit when all its children are dead.

Using CMD puts a shell between the PAUSE container and the
running process.  The shell doesn't properly pass on the SIGTERM.

Using ENTRYPOINT removes that intermediate shell, and allows
the container to exit much much faster in K8s.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
