### PR TITLE
Properly handle disconnects when watching config map updates

### DIFF
--- a/internal/prefixcollector/prefixsource/config_map_prefix_source.go
+++ b/internal/prefixcollector/prefixsource/config_map_prefix_source.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2022 Cisco and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/prefixcollector/prefixsource/config_map_prefix_source.go
+++ b/internal/prefixcollector/prefixsource/config_map_prefix_source.go
@@ -70,12 +70,12 @@ func (cmps *ConfigMapPrefixSource) Prefixes() []string {
 }
 
 func (cmps *ConfigMapPrefixSource) watchConfigMap() {
-	cmps.checkCurrentConfigMap()
 	configMapWatch, err := cmps.configMapInterface.Watch(cmps.ctx, metav1.ListOptions{})
 	if err != nil {
 		log.FromContext(cmps.ctx).Errorf("Error creating config map watch: %v", err)
 		return
 	}
+	cmps.checkCurrentConfigMap()
 
 	log.FromContext(cmps.ctx).Info("Starting watching configmaps")
 

--- a/internal/prefixcollector/prefixsource/config_map_prefix_source.go
+++ b/internal/prefixcollector/prefixsource/config_map_prefix_source.go
@@ -77,6 +77,9 @@ func (cmps *ConfigMapPrefixSource) watchConfigMap() {
 		log.FromContext(cmps.ctx).Errorf("Error creating config map watch: %v", err)
 		return
 	}
+
+	// we should check current state after we create the watcher,
+	// or else we could miss an update
 	cmps.checkCurrentConfigMap()
 
 	log.FromContext(cmps.ctx).Info("Starting watching configmaps")

--- a/internal/prefixcollector/prefixsource/kubeadm_prefix_source.go
+++ b/internal/prefixcollector/prefixsource/kubeadm_prefix_source.go
@@ -83,6 +83,8 @@ func (kaps *KubeAdmPrefixSource) watchKubeAdmConfigMap() {
 		return
 	}
 
+	// we should check current state after we create the watcher,
+	// or else we could miss an update
 	kaps.checkCurrentConfigMap()
 
 	for {

--- a/internal/prefixcollector/prefixsource/kubeadm_prefix_source.go
+++ b/internal/prefixcollector/prefixsource/kubeadm_prefix_source.go
@@ -88,7 +88,7 @@ func (kaps *KubeAdmPrefixSource) watchKubeAdmConfigMap() {
 	for {
 		select {
 		case <-kaps.ctx.Done():
-			log.FromContext(kaps.ctx).Warn("kubeadm configMap context is cancelled")
+			log.FromContext(kaps.ctx).Warn("kubeadm configMap context is canceled")
 			return
 		case event, ok := <-configMapWatch.ResultChan():
 			if !ok {

--- a/internal/prefixcollector/prefixsource/kubeadm_prefix_source.go
+++ b/internal/prefixcollector/prefixsource/kubeadm_prefix_source.go
@@ -77,12 +77,13 @@ func NewKubeAdmPrefixSource(ctx context.Context, notify chan<- struct{}) *KubeAd
 func (kaps *KubeAdmPrefixSource) watchKubeAdmConfigMap() {
 	log.FromContext(kaps.ctx).Infof("Watch kubeadm configMap")
 
-	kaps.checkCurrentConfigMap()
 	configMapWatch, err := kaps.configMapInterface.Watch(kaps.ctx, metav1.ListOptions{})
 	if err != nil {
 		log.FromContext(kaps.ctx).Errorf("Error creating config map watch: %v", err)
 		return
 	}
+
+	kaps.checkCurrentConfigMap()
 
 	for {
 		select {

--- a/internal/prefixcollector/prefixsource/kubernetes_prefix_source.go
+++ b/internal/prefixcollector/prefixsource/kubernetes_prefix_source.go
@@ -59,6 +59,8 @@ func NewKubernetesPrefixSource(ctx context.Context, notify chan<- struct{}) *Kub
 }
 
 func (kps *KubernetesPrefixSource) watchSubnets(clientSet kubernetes.Interface) {
+	log.FromContext(kps.ctx).Infof("KubernetesPrefixSource watch subnets")
+
 	podChan, err := watchPodCIDR(kps.ctx, clientSet)
 	if err != nil {
 		return
@@ -78,14 +80,17 @@ func (kps *KubernetesPrefixSource) waitForSubnets(podChan, serviceChan <-chan []
 	for {
 		select {
 		case <-kps.ctx.Done():
+			log.FromContext(kps.ctx).Warn("Watch kubeadm configMap")
 			return
 		case subnet, ok := <-podChan:
 			if !ok {
+				log.FromContext(kps.ctx).Warn("podChan watcher closed")
 				return
 			}
 			podPrefixes = subnet
 		case subnet, ok := <-serviceChan:
 			if !ok {
+				log.FromContext(kps.ctx).Warn("serviceChan closed")
 				return
 			}
 			svcPrefixes = subnet

--- a/pkg/imports/imports.go
+++ b/pkg/imports/imports.go
@@ -28,6 +28,7 @@ import (
 	_ "k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/kubernetes/fake"
 	_ "k8s.io/client-go/kubernetes/typed/core/v1"
+	_ "k8s.io/client-go/testing"
 	_ "math/big"
 	_ "net"
 	_ "os"


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->

Currently when an error happens during listening for config map updates, the app stops listening.
This PR fixes that by reconnecting after an error.

## Issue link
<!--- Please link to the issue here. -->

https://github.com/networkservicemesh/cmd-exclude-prefixes-k8s/issues/183

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] Added unit testing to cover
- [x] Tested manually
- [x] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [x] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [ ] Refactoring
- [ ] CI
